### PR TITLE
Move lookup dicts into `components.util`

### DIFF
--- a/skgstat_uncertainty/chapters/learn_geostatistics.py
+++ b/skgstat_uncertainty/chapters/learn_geostatistics.py
@@ -16,6 +16,7 @@ This application will guide you through the estimation of an empirical variogram
 You will learn about the parameters step by step and learn how to fit a model function. 
 If you are already familiar with variogram fitting, you can directly jump into the full fitting interface.
 """
+
 __data_intro = """
 First of all, you need to select one of the pre-definded data uploads. If you have access to the 
 full Uncertain Geostatistics app by [hydrocode](https://hydrocode.de) (LINK HERE), you can use the data-manage
@@ -24,6 +25,7 @@ Use the dropdown to inspect the datasets
 
 Once you found an exciting dataset, click on *continue* to get started with geostatistics!
 """
+
 __bin_intro = """
 To learn about spatial correlation in the dataset, that is not dependent on the location, we
 need to calculate separating distances between observations. This way, we can correlate observation similarity

--- a/skgstat_uncertainty/chapters/learn_geostatistics.py
+++ b/skgstat_uncertainty/chapters/learn_geostatistics.py
@@ -8,17 +8,9 @@ import skgstat as skg
 from skgstat_uncertainty.api import API
 from skgstat_uncertainty import components
 from skgstat_uncertainty.models import DataUpload
+from skgstat_uncertainty.components.utils import FIT_METHODS, MODELS, BIN_FUNC, ESTIMATORS
 
-# TODO: move them into defaults sub-module
-from skgstat_uncertainty.chapters.variogram import BIN_FUNC, ESTIMATORS
-from skgstat_uncertainty.chapters.model_fitting import MODELS
 
-FIT_METHODS = {
-    'trf': 'Trust-Region Reflective',
-    'lm': 'Levenberg-Marquardt',
-    'ml': 'Parameter Maximum Likelihood',
-    'manual': 'Manual Fitting' 
-}
 __story_intro = """
 This application will guide you through the estimation of an empirical variogram. 
 You will learn about the parameters step by step and learn how to fit a model function. 

--- a/skgstat_uncertainty/chapters/model_fitting.py
+++ b/skgstat_uncertainty/chapters/model_fitting.py
@@ -11,16 +11,7 @@ from skgstat_uncertainty.api import API
 from skgstat_uncertainty.models import VarioModel, VarioParams, VarioConfInterval
 from skgstat_uncertainty.processor import fit
 from skgstat_uncertainty import components
-
-
-MODELS = {
-    'spherical': 'Spherical',
-    'exponential': 'Exponential',
-    'gaussian': 'Gaussian',
-    'cubic': 'Cubic',
-    'stable': 'Stable',
-    'matern': 'Matérn'
-}
+from skgstat_uncertainty.components.utils import MODELS
 
 
 def apply_model(vario: VarioParams, interval: VarioConfInterval, figure: go.Figure, other_models: List[VarioModel] = []) -> Tuple[go.Figure, dict]:

--- a/skgstat_uncertainty/chapters/variogram.py
+++ b/skgstat_uncertainty/chapters/variogram.py
@@ -10,44 +10,8 @@ from skgstat_uncertainty.api import API
 from skgstat_uncertainty.models import DataUpload
 from skgstat_uncertainty.processor import sampling
 from skgstat_uncertainty import components
+from skgstat_uncertainty.components.utils import BIN_FUNC, ESTIMATORS, MAXLAG, CONF_METHODS
 from skgstat_uncertainty.processor import exp_variogram_uncertainty as variogram_processor
-
-
-# create some mappings
-BIN_FUNC = dict(
-    even='Evenly spaced bins',
-    uniform='Uniformly distributed bin sizes',
-    kmeans='K-Means clustered bins',
-    ward='hierachical clustered bins',
-    sturges="Sturge's rule binning",
-    scott="Scott's rule binning",
-    sqrt="Squareroot rule binning",
-    fd="Freedman-Diaconis estimator binning",
-    doane="Doane's rule binning"
-)
-
-ESTIMATORS = dict(
-    matheron="Matheron estimator",
-    cressie="Cressie-Hawkins estimator",
-    dowd="Dowd estimator",
-    genton="Genton estimator",
-    entropy="Shannon entropy"
-)
-
-MAXLAG = dict(
-    median="Median value",
-    mean="Mean value",
-    ratio="Ratio of max distance",
-    absolute="Absolute value",
-    none="Disable maxlag"
-)
-
-CONF_METHODS = dict(
-    std="Sample standard deviation inference",
-    kfold="Bootstraped k-fold cross-validation",
-    absolute="Observation uncertainty propagation (MC)",
-    residual="Residual extrema elimination",
-)
 
 
 def variogram_manual_fit(dataset: DataUpload) -> Variogram:

--- a/skgstat_uncertainty/components/utils.py
+++ b/skgstat_uncertainty/components/utils.py
@@ -19,3 +19,56 @@ def variomodel_to_dict(models: List[VarioModel], add_measures = False) -> List[d
         data.append(d)
 
     return data
+
+
+# add some constants
+FIT_METHODS = {
+    'trf': 'Trust-Region Reflective',
+    'lm': 'Levenberg-Marquardt',
+    'ml': 'Parameter Maximum Likelihood',
+    'manual': 'Manual Fitting' 
+}
+
+MODELS = {
+    'spherical': 'Spherical',
+    'exponential': 'Exponential',
+    'gaussian': 'Gaussian',
+    'cubic': 'Cubic',
+    'stable': 'Stable',
+    'matern': 'Matérn'
+}
+
+BIN_FUNC = dict(
+    even='Evenly spaced bins',
+    uniform='Uniformly distributed bin sizes',
+    kmeans='K-Means clustered bins',
+    ward='hierachical clustered bins',
+    sturges="Sturge's rule binning",
+    scott="Scott's rule binning",
+    sqrt="Squareroot rule binning",
+    fd="Freedman-Diaconis estimator binning",
+    doane="Doane's rule binning"
+)
+
+ESTIMATORS = dict(
+    matheron="Matheron estimator",
+    cressie="Cressie-Hawkins estimator",
+    dowd="Dowd estimator",
+    genton="Genton estimator",
+    entropy="Shannon entropy"
+)
+
+MAXLAG = dict(
+    median="Median value",
+    mean="Mean value",
+    ratio="Ratio of max distance",
+    absolute="Absolute value",
+    none="Disable maxlag"
+)
+
+CONF_METHODS = dict(
+    std="Sample standard deviation inference",
+    kfold="Bootstraped k-fold cross-validation",
+    absolute="Observation uncertainty propagation (MC)",
+    residual="Residual extrema elimination",
+)


### PR DESCRIPTION
Lookup dictionaries to build selects in streamlit are now globally moved to `components.utils` and can be imported by the application from everywhere.